### PR TITLE
Update 2025.md

### DIFF
--- a/docs/internships/gsoc-previous/2025.md
+++ b/docs/internships/gsoc-previous/2025.md
@@ -4,7 +4,7 @@ title: 2025
 sidebar_position: 3
 ---
 
-Our GSoC 2024 ideas.
+Our GSoC 2025 ideas.
 
 ## Talawa Areas
 


### PR DESCRIPTION
make gsoc previous ideas from 2024 to 2025 as this was for gsoc previous ideas of year 2025

 <!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Bugfix
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #41 

**Did you add tests for your changes?**

No

**If relevant, did you update the documentation?**

Yes

**Summary**
It was creating confusion as if the page was showing gsoc previous projects for 2024 of 2025.It is actually 2025 but wrongly written as 2024
**Does this PR introduce a breaking change?**

NO

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/developer-docs/blob/main/CONTRIBUTING.md)?**

Yes