### PR TITLE
Fixed slack link

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -126,9 +126,9 @@ const config: Config = {
           title: 'Community',
           items: [
             {
-              label: ' Slack',
-              to: 'https://github.com/PalisadoesFoundation',
-              className: 'footer__icon footer__slack',
+              label: 'Forums',
+              to: 'https://community.talawa.io/',
+              className: 'footer__icon footer__news',
             },
             {
               label: ' News',


### PR DESCRIPTION
Fixed slack link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Changed the footer's community link to direct users to the community forum at https://community.talawa.io/ instead of GitHub, and updated the label from "Slack" to "Forums".

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->