### PR TITLE
Fixed incorrect '.github' repo reference 1770400243

### DIFF
--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -5,6 +5,6 @@ on:
 
 jobs:
   PR-Greeting:
-    uses: PalisadoesFoundation/.github/.github/workflows/pr-target-policy.yml@main
+    uses: PalisadoesFoundation/.github/.github/workflows/pull-request-target.yml@main
     secrets:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixed incorrect '.github' repo reference 1770400243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration to reference an alternative workflow module, maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->